### PR TITLE
Fix for astroid AttributeInferenceError

### DIFF
--- a/pylint_requests/utils.py
+++ b/pylint_requests/utils.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from astroid import AstroidIndexError, AstroidTypeError, InferenceError, bases, nodes
+from astroid.exceptions import AttributeInferenceError
 from astroid.node_classes import NodeNG
 
 FUNCTION_NODES = (nodes.FunctionDef, bases.UnboundMethod, bases.BoundMethod)
@@ -59,10 +60,13 @@ def _lookup(node: NodeNG) -> List[NodeNG]:
         try:
             obj = next(node.expr.infer())
         except InferenceError:
-            pass
-        else:
-            if isinstance(obj, bases.Instance):
+            return []
+
+        if isinstance(obj, bases.Instance):
+            try:
                 return obj.getattr(node.attrname)
+            except AttributeInferenceError:
+                return []
 
     return []
 

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -40,6 +40,17 @@ class TestTimeoutChecker(CheckerTestCase):
         with self.assertAddsMessages(Message('request-without-timeout', node=node)):
             self.walk(node.root())
 
+    def test_optional_param_attribute_access(self):
+        node = extract_node(
+            '''
+            def get_something_from_document_or_none(document=None):
+                if document is not None:
+                    return document.META.get('QUERY_STRING')
+            '''
+        )
+        with self.assertNoMessages():
+            self.walk(node.root())
+
 
 class TestRequestsInstalledChecker(CheckerTestCase):
     CHECKER_CLASS = RequestsInstalledChecker


### PR DESCRIPTION
My proposal to fix #1 crash. It is still able to find requests without timeout usage even in the file where the crash was happening.